### PR TITLE
Add permissions block to github container build

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -26,6 +26,9 @@ jobs:
 
   build-singularity:
     needs: build-docker
+    permissions:
+      actions: read
+      packages: write
     runs-on: ubuntu-latest
     container:
       image: quay.io/singularity/singularity:v3.10.0


### PR DESCRIPTION
Right now it is erroring out with a 403, which I think is due to some difference between public and private repository default configuration