### PR TITLE
Remove Libpysal Warnings

### DIFF
--- a/src/bayestme/spatial_expression.py
+++ b/src/bayestme/spatial_expression.py
@@ -322,7 +322,7 @@ def moran_i(
         neighbours[i] = nb
         weights[i] = [1] * len(nb)
 
-    w = pysal_Weights(neighbours, weights)
+    w = pysal_Weights(neighbours, weights, silence_warnings=True)
 
     result = np.zeros(data.shape[:-1])
     for k in range(data.shape[0]):


### PR DESCRIPTION
The authors of this package put a raw print statement inside of a tight loop that prints info level messages.. but at least they also have a parameter to disable it..