### PR TITLE
Fix R Packages

### DIFF
--- a/seurat_fine_mapping/Dockerfile
+++ b/seurat_fine_mapping/Dockerfile
@@ -1,7 +1,7 @@
 FROM satijalab/seurat:latest
 
-RUN R -e "install.packages(c('optparse', 'devtools'), dependencies=TRUE)" && \
-    R -e "devtools::install_github('haotian-zhuang/findPC')"
+RUN R -e "install.packages(c('optparse', 'remotes'), dependencies=TRUE)" && \
+    R -e "remotes::install_github('haotian-zhuang/findPC')"
 
 COPY /seurat_fine_mapping/entrypoint.sh /
 


### PR DESCRIPTION
Apparently the `devtools` package doesn't build on ubuntu out of the box.. so people have written a lighter weight package that lets you install from github, let's use that instead.