### PR TITLE
Fix Handling of Barcode Labels in AnnData

### DIFF
--- a/src/bayestme/data.py
+++ b/src/bayestme/data.py
@@ -82,11 +82,11 @@ class SpatialExpressionDataset:
 
     @property
     def reads(self) -> np.ndarray:
-        return self.adata.X[self.adata.obs[IN_TISSUE_ATTR]]
+        return self.adata[self.adata.obs[IN_TISSUE_ATTR]].X
 
     @property
     def positions_tissue(self) -> np.ndarray:
-        return self.adata.obsm[SPATIAL_ATTR][self.adata.obs[IN_TISSUE_ATTR]]
+        return self.adata[self.adata.obs[IN_TISSUE_ATTR]].obsm[SPATIAL_ATTR]
 
     @property
     def n_spot_in(self) -> int:
@@ -132,12 +132,12 @@ class SpatialExpressionDataset:
     @property
     def cell_type_probabilities(self) -> Optional[np.ndarray]:
         if CELL_TYPE_PROB_ATTR in self.adata.obsm:
-            return self.adata.obsm[CELL_TYPE_PROB_ATTR][self.tissue_mask]
+            return self.adata[self.tissue_mask].obsm[CELL_TYPE_PROB_ATTR]
 
     @property
     def cell_type_counts(self) -> Optional[np.ndarray]:
         if CELL_TYPE_COUNT_ATTR in self.adata.obsm:
-            return self.adata.obsm[CELL_TYPE_COUNT_ATTR][self.tissue_mask]
+            return self.adata[self.tissue_mask].obsm[CELL_TYPE_COUNT_ATTR]
 
     @property
     def marker_gene_names(self) -> Optional[List[np.ndarray]]:

--- a/src/bayestme/gene_filtering.py
+++ b/src/bayestme/gene_filtering.py
@@ -15,8 +15,8 @@ class FilterType(Enum):
 
 
 def select_top_genes_by_standard_deviation(
-        dataset: data.SpatialExpressionDataset,
-        n_gene: int) -> data.SpatialExpressionDataset:
+    dataset: data.SpatialExpressionDataset,
+    n_gene: int) -> data.SpatialExpressionDataset:
     # order genes by the standard deviation across spots
     ordering = utils.get_stddev_ordering(dataset.reads)
 
@@ -24,16 +24,10 @@ def select_top_genes_by_standard_deviation(
 
     logger.info('filtering top {} genes from original {} genes...'.format(n_top_genes, dataset.n_gene))
     n_gene_filter = ordering[:n_top_genes]
-    filtered_raw_counts = dataset.raw_counts[:, n_gene_filter]
-    filtered_gene_names = dataset.gene_names[n_gene_filter]
 
-    return data.SpatialExpressionDataset.from_arrays(
-        raw_counts=filtered_raw_counts,
-        positions=dataset.positions,
-        tissue_mask=dataset.tissue_mask,
-        gene_names=filtered_gene_names,
-        layout=dataset.layout
-    )
+    input_adata = dataset.adata
+
+    return data.SpatialExpressionDataset(input_adata[:, n_gene_filter])
 
 
 def filter_genes_by_spot_threshold(dataset: data.SpatialExpressionDataset, spot_threshold: float):
@@ -41,16 +35,8 @@ def filter_genes_by_spot_threshold(dataset: data.SpatialExpressionDataset, spot_
 
     keep = (dataset.reads > 0).sum(axis=0) < int(n_spots * spot_threshold)
 
-    filtered_raw_counts = dataset.raw_counts[:, keep]
-    filtered_gene_names = dataset.gene_names[keep]
-
-    return data.SpatialExpressionDataset.from_arrays(
-        raw_counts=filtered_raw_counts,
-        positions=dataset.positions,
-        tissue_mask=dataset.tissue_mask,
-        gene_names=filtered_gene_names,
-        layout=dataset.layout
-    )
+    input_adata = dataset.adata
+    return data.SpatialExpressionDataset(input_adata[:, keep])
 
 
 RIBOSOME_GENE_NAME_PATTERN = '[Rr][Pp][SsLl]'
@@ -59,31 +45,15 @@ RIBOSOME_GENE_NAME_PATTERN = '[Rr][Pp][SsLl]'
 def filter_ribosome_genes(dataset: data.SpatialExpressionDataset):
     keep = ~np.array([bool(re.match(RIBOSOME_GENE_NAME_PATTERN, g)) for g in dataset.gene_names], dtype=np.bool)
 
-    filtered_raw_counts = dataset.raw_counts[:, keep]
-    filtered_gene_names = dataset.gene_names[keep]
-
-    return data.SpatialExpressionDataset.from_arrays(
-        raw_counts=filtered_raw_counts,
-        positions=dataset.positions,
-        tissue_mask=dataset.tissue_mask,
-        gene_names=filtered_gene_names,
-        layout=dataset.layout
-    )
+    input_adata = dataset.adata
+    return data.SpatialExpressionDataset(input_adata[:, keep])
 
 
 def filter_list_of_genes(dataset: data.SpatialExpressionDataset, genes_to_remove):
     keep = ~np.array([g in genes_to_remove for g in dataset.gene_names], dtype=np.bool)
 
-    filtered_raw_counts = dataset.raw_counts[:, keep]
-    filtered_gene_names = dataset.gene_names[keep]
-
-    return data.SpatialExpressionDataset.from_arrays(
-        raw_counts=filtered_raw_counts,
-        positions=dataset.positions,
-        tissue_mask=dataset.tissue_mask,
-        gene_names=filtered_gene_names,
-        layout=dataset.layout
-    )
+    input_adata = dataset.adata
+    return data.SpatialExpressionDataset(input_adata[:, keep])
 
 
 def filter_stdata_to_match_expression_truth(stdata: data.SpatialExpressionDataset,

--- a/src/bayestme/gene_filtering_test.py
+++ b/src/bayestme/gene_filtering_test.py
@@ -24,8 +24,9 @@ def test_select_top_genes_by_standard_deviation():
     gene_names = np.array(['keep_me1',
                            'keep_me2',
                            'filter'])
+    barcodes = np.array([f'barcode{i}' for i in range(3)])
 
-    dataset = data.SpatialExpressionDataset.from_arrays(
+    dataset_without_obs_names = data.SpatialExpressionDataset.from_arrays(
         raw_counts=raw_counts,
         tissue_mask=tissue_mask,
         positions=locations,
@@ -33,24 +34,34 @@ def test_select_top_genes_by_standard_deviation():
         layout=data.Layout.SQUARE
     )
 
-    # When: select_top_genes_by_standard_deviation is called to select the top 2 genes
-    n_genes_filter = 2
-    result = gene_filtering.select_top_genes_by_standard_deviation(dataset, n_genes_filter)
-
-    (n_spots_in, n_genes) = result.reads.shape
-
-    # Then: the 2 high variation genes are selected
-    assert n_genes == n_genes_filter
-    assert n_spots_in == 3
-    np.testing.assert_equal(
-        result.reads,
-        np.array(
-            [[199, 200],
-             [10000, 10001],
-             [1, 3]], dtype=np.int64
-        )
+    dataset_with_obs_names = data.SpatialExpressionDataset.from_arrays(
+        raw_counts=raw_counts,
+        tissue_mask=tissue_mask,
+        positions=locations,
+        gene_names=gene_names,
+        layout=data.Layout.SQUARE,
+        barcodes=barcodes
     )
-    np.testing.assert_equal(result.gene_names, np.array(['keep_me1', 'keep_me2']))
+
+    for dataset in [dataset_with_obs_names, dataset_without_obs_names]:
+        # When: select_top_genes_by_standard_deviation is called to select the top 2 genes
+        n_genes_filter = 2
+        result = gene_filtering.select_top_genes_by_standard_deviation(dataset, n_genes_filter)
+
+        (n_spots_in, n_genes) = result.reads.shape
+
+        # Then: the 2 high variation genes are selected
+        assert n_genes == n_genes_filter
+        assert n_spots_in == 3
+        np.testing.assert_equal(
+            result.reads,
+            np.array(
+                [[199, 200],
+                 [10000, 10001],
+                 [1, 3]], dtype=np.int64
+            )
+        )
+        np.testing.assert_equal(result.gene_names, np.array(['keep_me1', 'keep_me2']))
 
 
 def test_filter_genes_by_spot_threshold():
@@ -71,7 +82,9 @@ def test_filter_genes_by_spot_threshold():
                            'filter2',
                            'keep_me'])
 
-    dataset = data.SpatialExpressionDataset.from_arrays(
+    barcodes = np.array([f'barcode{i}' for i in range(3)])
+
+    dataset_without_obs_names = data.SpatialExpressionDataset.from_arrays(
         raw_counts=raw_counts,
         tissue_mask=tissue_mask,
         positions=locations,
@@ -79,23 +92,33 @@ def test_filter_genes_by_spot_threshold():
         layout=data.Layout.SQUARE
     )
 
-    # When: filter_genes_by_spot_threshold is called with threshold 0.5
-
-    result = gene_filtering.filter_genes_by_spot_threshold(dataset, spot_threshold=0.5)
-
-    (n_spots_in, n_genes) = result.reads.shape
-
-    # Then: only the gene which appears in 0% of spots is kept
-    assert n_genes == 1
-    np.testing.assert_equal(
-        result.reads,
-        np.array(
-            [[0],
-             [0],
-             [0]], dtype=np.int64
-        )
+    dataset_with_obs_names = data.SpatialExpressionDataset.from_arrays(
+        raw_counts=raw_counts,
+        tissue_mask=tissue_mask,
+        positions=locations,
+        gene_names=gene_names,
+        layout=data.Layout.SQUARE,
+        barcodes=barcodes
     )
-    np.testing.assert_equal(result.gene_names, np.array(['keep_me']))
+
+    for dataset in [dataset_with_obs_names, dataset_without_obs_names]:
+        # When: filter_genes_by_spot_threshold is called with threshold 0.5
+
+        result = gene_filtering.filter_genes_by_spot_threshold(dataset, spot_threshold=0.5)
+
+        (n_spots_in, n_genes) = result.reads.shape
+
+        # Then: only the gene which appears in 0% of spots is kept
+        assert n_genes == 1
+        np.testing.assert_equal(
+            result.reads,
+            np.array(
+                [[0],
+                 [0],
+                 [0]], dtype=np.int64
+            )
+        )
+        np.testing.assert_equal(result.gene_names, np.array(['keep_me']))
 
 
 def test_filter_ribosome_genes():
@@ -115,7 +138,8 @@ def test_filter_ribosome_genes():
     gene_names = np.array(['RPL333',
                            'other',
                            'other2'])
-    dataset = data.SpatialExpressionDataset.from_arrays(
+    barcodes = np.array([f'barcode{i}' for i in range(3)])
+    dataset_without_obs_names = data.SpatialExpressionDataset.from_arrays(
         raw_counts=raw_counts,
         tissue_mask=tissue_mask,
         positions=locations,
@@ -123,22 +147,32 @@ def test_filter_ribosome_genes():
         layout=data.Layout.SQUARE
     )
 
-    # When: filter_ribosome_genes is called
-    result = gene_filtering.filter_ribosome_genes(dataset)
-
-    (n_spots_in, n_genes) = result.reads.shape
-
-    # Then: only the two genes with non matching names are kept
-    assert n_genes == 2
-    np.testing.assert_equal(
-        result.reads,
-        np.array(
-            [[1, 2],
-             [2, 3],
-             [3, 4]], dtype=np.int64
-        )
+    dataset_with_obs_names = data.SpatialExpressionDataset.from_arrays(
+        raw_counts=raw_counts,
+        tissue_mask=tissue_mask,
+        positions=locations,
+        gene_names=gene_names,
+        layout=data.Layout.SQUARE,
+        barcodes=barcodes
     )
-    np.testing.assert_equal(result.gene_names, np.array(['other', 'other2']))
+
+    for dataset in [dataset_with_obs_names, dataset_without_obs_names]:
+        # When: filter_ribosome_genes is called
+        result = gene_filtering.filter_ribosome_genes(dataset)
+
+        (n_spots_in, n_genes) = result.reads.shape
+
+        # Then: only the two genes with non matching names are kept
+        assert n_genes == 2
+        np.testing.assert_equal(
+            result.reads,
+            np.array(
+                [[1, 2],
+                 [2, 3],
+                 [3, 4]], dtype=np.int64
+            )
+        )
+        np.testing.assert_equal(result.gene_names, np.array(['other', 'other2']))
 
 
 def test_filter_list_of_genes():
@@ -154,11 +188,11 @@ def test_filter_list_of_genes():
     ])
 
     tissue_mask = np.array([True for _ in range(3)])
-
     gene_names = np.array(['RPL333',
                            'other',
                            'other2'])
-    dataset = data.SpatialExpressionDataset.from_arrays(
+    barcodes = np.array([f'barcode{i}' for i in range(3)])
+    dataset_without_obs_names = data.SpatialExpressionDataset.from_arrays(
         raw_counts=raw_counts,
         tissue_mask=tissue_mask,
         positions=locations,
@@ -166,22 +200,32 @@ def test_filter_list_of_genes():
         layout=data.Layout.SQUARE
     )
 
-    # When: filter_list_of_genes is called
-    result = gene_filtering.filter_list_of_genes(dataset, ['other', 'other2'])
-
-    (n_spots_in, n_genes) = result.reads.shape
-
-    # Then: only the gene not on the list remains
-    assert n_genes == 1
-    np.testing.assert_equal(
-        result.reads,
-        np.array(
-            [[7],
-             [8],
-             [9]], dtype=np.int64
-        )
+    dataset_with_obs_names = data.SpatialExpressionDataset.from_arrays(
+        raw_counts=raw_counts,
+        tissue_mask=tissue_mask,
+        positions=locations,
+        gene_names=gene_names,
+        layout=data.Layout.SQUARE,
+        barcodes=barcodes
     )
-    np.testing.assert_equal(result.gene_names, np.array(['RPL333']))
+
+    for dataset in [dataset_with_obs_names, dataset_without_obs_names]:
+        # When: filter_list_of_genes is called
+        result = gene_filtering.filter_list_of_genes(dataset, ['other', 'other2'])
+
+        (n_spots_in, n_genes) = result.reads.shape
+
+        # Then: only the gene not on the list remains
+        assert n_genes == 1
+        np.testing.assert_equal(
+            result.reads,
+            np.array(
+                [[7],
+                 [8],
+                 [9]], dtype=np.int64
+            )
+        )
+        np.testing.assert_equal(result.gene_names, np.array(['RPL333']))
 
 
 def test_filter_stdata_to_match_expression_truth():


### PR DESCRIPTION
Addresses #68 

Fix anndata slicing in various places to handle cases where `adata.obs_names` is not the default integer index, and is instead a string index of barcode names.