### PR TITLE
Add Numpy as Documentation Dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,6 @@ html_theme = 'alabaster'
 html_static_path = ['_static']
 
 autodoc_mock_imports = [
-    'np',
     'numpy',
     'matplotlib',
     'torch',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx-argparse
+numpy


### PR DESCRIPTION
There doesnt seem to be any good way to avoid doing this, since one of the cli argparse classes imports numpy