### PR TITLE
Fix Handling of Barcodes During Bleed Correction

### DIFF
--- a/src/bayestme/bleeding_correction.py
+++ b/src/bayestme/bleeding_correction.py
@@ -637,7 +637,8 @@ def clean_bleed(dataset: data.SpatialExpressionDataset,
         tissue_mask=dataset.tissue_mask,
         positions=dataset.positions,
         gene_names=dataset.gene_names,
-        layout=dataset.layout
+        layout=dataset.layout,
+        barcodes=dataset.adata.obs.index.to_numpy()
     )
 
     bleed_correction_result = data.BleedCorrectionResult(

--- a/src/bayestme/bleeding_correction_test.py
+++ b/src/bayestme/bleeding_correction_test.py
@@ -122,7 +122,16 @@ def test_clean_bleed():
         n_cols=12,
         n_genes=5)
 
-    dataset = data.SpatialExpressionDataset.from_arrays(
+    dataset1 = data.SpatialExpressionDataset.from_arrays(
+        raw_counts=bleed_counts,
+        tissue_mask=tissue_mask,
+        positions=locations,
+        gene_names=np.array(['1', '2', '3', '4', '5']),
+        layout=data.Layout.SQUARE,
+        barcodes=np.array(['barcode' + str(i) for i in range(len(locations))])
+    )
+
+    dataset2 = data.SpatialExpressionDataset.from_arrays(
         raw_counts=bleed_counts,
         tissue_mask=tissue_mask,
         positions=locations,
@@ -130,14 +139,16 @@ def test_clean_bleed():
         layout=data.Layout.SQUARE
     )
 
-    (cleaned_dataset, bleed_correction_result) = bleeding_correction.clean_bleed(
-        dataset,
-        n_top=3,
-        local_weight=None)
+    for dataset in [dataset1, dataset2]:
+        (cleaned_dataset, bleed_correction_result) = bleeding_correction.clean_bleed(
+            dataset,
+            n_top=3,
+            local_weight=None)
 
-    assert cleaned_dataset.n_gene == 5
-    assert bleed_correction_result.corrected_reads.shape == (12*12, 5)
-    assert bleed_correction_result.global_rates.shape == (5, )
+        assert cleaned_dataset.n_gene == 5
+        assert bleed_correction_result.corrected_reads.shape == (12*12, 5)
+        assert bleed_correction_result.global_rates.shape == (5, )
+        assert cleaned_dataset.n_spot_in == tissue_mask.sum()
 
 
 def test_plot_bleed_vectors():

--- a/src/bayestme/data.py
+++ b/src/bayestme/data.py
@@ -110,7 +110,7 @@ class SpatialExpressionDataset:
 
     @property
     def tissue_mask(self) -> np.array:
-        return self.adata.obs[IN_TISSUE_ATTR]
+        return self.adata.obs[IN_TISSUE_ATTR].to_numpy()
 
     @property
     def gene_names(self) -> np.array:

--- a/src/bayestme/data_test.py
+++ b/src/bayestme/data_test.py
@@ -29,7 +29,8 @@ def generate_toy_stdataset() -> data.SpatialExpressionDataset:
         tissue_mask=tissue_mask,
         positions=locations,
         gene_names=gene_names,
-        layout=data.Layout.SQUARE
+        layout=data.Layout.SQUARE,
+        barcodes=np.array(['1', '2', '3'])
     )
 
 

--- a/src/bayestme/synthetic_data.py
+++ b/src/bayestme/synthetic_data.py
@@ -133,4 +133,5 @@ def generate_fake_stdataset(
         tissue_mask=tissue_mask,
         positions=locations,
         gene_names=np.array(['{}'.format(x) for x in range(n_genes)]),
-        layout=layout)
+        layout=layout,
+        barcodes=np.array(['barcode' + str(i) for i in range(len(locations))]))


### PR DESCRIPTION
The tissue_mask attribute on the anndata object returns a pandas.Series instead of an np.array, which is wrong, and this creates a subtle bug when the obs_names are not numbers