### PR TITLE
Default to No Selection Criteria for Marker Genes

### DIFF
--- a/src/bayestme/cli/select_marker_genes.py
+++ b/src/bayestme/cli/select_marker_genes.py
@@ -46,7 +46,7 @@ def get_parser():
         "--marker-gene-method",
         type=bayestme.marker_genes.MarkerGeneMethod,
         choices=list(bayestme.marker_genes.MarkerGeneMethod),
-        default=bayestme.marker_genes.MarkerGeneMethod.TIGHT,
+        default=bayestme.marker_genes.MarkerGeneMethod.BEST_AVAILABLE,
         help="Method for choosing marker genes.",
     )
     bayestme.log_config.add_logging_args(parser)

--- a/src/bayestme/marker_genes.py
+++ b/src/bayestme/marker_genes.py
@@ -12,6 +12,7 @@ from bayestme.mcmc.deconvolution import logger
 
 class MarkerGeneMethod(Enum):
     TIGHT = "TIGHT"
+    BEST_AVAILABLE = "BEST_AVAILABLE"
     FALSE_DISCOVERY_RATE = "FALSE_DISCOVERY_RATE"
 
     def __str__(self):
@@ -54,6 +55,8 @@ def select_marker_genes(
             )
             marker_control = np.argwhere(fdr <= alpha).flatten()
             marker_idx_control = sorted_index[marker_control]
+        elif method is MarkerGeneMethod.BEST_AVAILABLE:
+            marker_idx_control = np.arange(deconvolution_result.omega[k].shape[0])
         else:
             raise ValueError(method)
         # sort adjointly by omega_kg (primary) and expression level (secondary)

--- a/src/bayestme/marker_genes_test.py
+++ b/src/bayestme/marker_genes_test.py
@@ -97,6 +97,47 @@ def test_detect_marker_genes_fdr():
         assert len(marker_gene_set) == n_marker
 
 
+def test_detect_marker_genes_best_available():
+    n_components = 3
+    n_marker = 2
+    n_genes = 100
+    (
+        locations,
+        tissue_mask,
+        true_rates,
+        true_counts,
+        bleed_counts,
+    ) = bayestme.synthetic_data.generate_simulated_bleeding_reads_data(
+        n_rows=12, n_cols=12, n_genes=n_genes
+    )
+
+    dataset = data.SpatialExpressionDataset.from_arrays(
+        raw_counts=bleed_counts,
+        tissue_mask=tissue_mask,
+        positions=locations,
+        gene_names=np.array(["{}".format(x) for x in range(n_genes)]),
+        layout=data.Layout.SQUARE,
+    )
+
+    deconvolve_results = create_toy_deconvolve_result(
+        n_nodes=dataset.n_spot_in,
+        n_components=n_components,
+        n_samples=100,
+        n_gene=dataset.n_gene,
+    )
+
+    marker_genes = bayestme.marker_genes.select_marker_genes(
+        deconvolution_result=deconvolve_results,
+        n_marker=n_marker,
+        alpha=0,
+        method=bayestme.marker_genes.MarkerGeneMethod.BEST_AVAILABLE,
+    )
+
+    assert len(marker_genes) == n_components
+    for marker_gene_set in marker_genes:
+        assert len(marker_gene_set) == n_marker
+
+
 def test_plot_marker_genes():
     tempdir = tempfile.mkdtemp()
     dataset = create_deconvolve_dataset(n_components=5)


### PR DESCRIPTION
Our current methods for selecting marker genes impose some constraints on what can be considered a true marker gene for a cell type. This produces a very confusing user experience when for instance, for the 12th out of 12 cell types, there are no valid marker genes. This causes the pipeline to crash. It might be a more sensible default to just pick the best available N genes and use those for the plots, and users can use the more strict criteria later on if they wish.