### PR TITLE
Handle More Input Data Edge Cases

### DIFF
--- a/src/bayestme/data.py
+++ b/src/bayestme/data.py
@@ -126,7 +126,7 @@ class SpatialExpressionDataset:
         X = self.adata.X
 
         if issparse(X):
-            return X.todense()
+            return np.asarray(X.todense())
         else:
             return X
 
@@ -135,7 +135,7 @@ class SpatialExpressionDataset:
         X = self.adata[self.adata.obs[IN_TISSUE_ATTR]].X
 
         if issparse(X):
-            return X.todense()
+            return np.asarray(X.todense())
         else:
             return X
 


### PR DESCRIPTION
It turns out that sparse/non sparse anndata has more edge cases we didn't catch. Addressing them here to make sure .counts actually returns a 2d numpy array as all the other code expects